### PR TITLE
Removes duplicate "also" in Create a copilot Step 2

### DIFF
--- a/Instructions/Labs/01-create-copilot.md
+++ b/Instructions/Labs/01-create-copilot.md
@@ -23,7 +23,7 @@ Let’s start by using Copilot Studio to create a new copilot. The copilot will 
 
     ![Screenshot of the Copilot Studio home page.](media/copilot-studio-home.png)
 
-    On the home page, you can start creating a copilot and view copilots you have recently worked on. The Power Apps **environment** in which your copilots are defined is shown at the top of the page. You can also also navigate to the **Create** page for more copilot creation options and the **Copilots** page to view all of your existing copilots.
+    On the home page, you can start creating a copilot and view copilots you have recently worked on. The Power Apps **environment** in which your copilots are defined is shown at the top of the page. You can also navigate to the **Create** page for more copilot creation options and the **Copilots** page to view all of your existing copilots.
 
     > **Note**: In addition to copilots you have created, you may see other copilots such as **Copilot for Microsoft 365**, which you can use Copilot Studio to extend.
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 01

Fixes [#1.](https://github.com/MicrosoftLearning/mslearn-copilotstudio/issues/1)

Changes proposed in this pull request:
Removes duplicate "also" in "Create a copilot" step 2.

https://microsoftlearning.github.io/mslearn-copilotstudio/Instructions/Labs/01-create-copilot.html#:~:text=You%20can%20also%20also%20navigate%20to%20the%20Create%20page%20for%20more%20copilot%20creation%20options%20and%20the%20Copilots%20page%20to%20view%20all%20of%20your%20existing%20copilots.