### PR TITLE
Backfill missing lab metadata (9 files)

### DIFF
--- a/Instructions/Labs/01-create-copilot.md
+++ b/Instructions/Labs/01-create-copilot.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Create an agent with Copilot Studio'
-    module: 'Build an initial agent with Microsoft Copilot Studio'
+  title: Create an agent with Copilot Studio
+  module: Build an initial agent with Microsoft Copilot Studio
+  description: In this exercise, you’ll use Copilot Studio to create a simple agent
+    that answers employee questions about expense policies in a fictional corporation.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Create an agent with Copilot Studio

--- a/Instructions/Labs/02-import-solution.md
+++ b/Instructions/Labs/02-import-solution.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Import Dataverse solution'
-    module: 'Build an initial agent with Microsoft Copilot Studio'
+  title: Import Dataverse solution
+  module: Build an initial agent with Microsoft Copilot Studio
+  description: In this exercise, you'll import a Dataverse solution to use in the
+    following labs. The solution includes a model-driven app for creating and managing
+    Real Estate Properties.
+  duration: 70 minutes
+  level: 100
+  islab: true
 ---
 
 # Import Dataverse solution

--- a/Instructions/Labs/03-create-copilot.md
+++ b/Instructions/Labs/03-create-copilot.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Build an initial agent'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Build an initial agent
+  module: Manage topics in Microsoft Copilot Studio
+  description: 'In this exercise, you will:'
+  duration: 84 minutes
+  level: 200
+  islab: true
 ---
 
 # Build an initial agent

--- a/Instructions/Labs/04-manage-topics.md
+++ b/Instructions/Labs/04-manage-topics.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Manage topics'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Manage topics
+  module: Manage topics in Microsoft Copilot Studio
+  description: 'In this exercise, you will:'
+  duration: 102 minutes
+  level: 100
+  islab: true
 ---
 
 # Manage topics

--- a/Instructions/Labs/05-manage-nodes.md
+++ b/Instructions/Labs/05-manage-nodes.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Manage nodes'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Manage nodes
+  module: Manage topics in Microsoft Copilot Studio
+  description: In this exercise, you will build a predictable, step-by-step conversation
+    flow using nodes while generative AI remains enabled. When generative AI is enabled,
+    the agent may respond dynamically to some prompts. Topics and nodes are used when
+    you need structured, repeatable outcomes—for example, collecting required information
+    in a fixed order.
+  duration: 152 minutes
+  level: 100
+  islab: true
 ---
 
 # Manage nodes

--- a/Instructions/Labs/06-entities.md
+++ b/Instructions/Labs/06-entities.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Work with entities'
-    module: 'Work with entities and variables in Microsoft Copilot Studio'
+  title: Work with entities
+  module: Work with entities and variables in Microsoft Copilot Studio
+  description: 'In this exercise, you will:'
+  duration: 122 minutes
+  level: 100
+  islab: true
 ---
 
 # Work with entities

--- a/Instructions/Labs/07-copilot-actions.md
+++ b/Instructions/Labs/07-copilot-actions.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Create agent flows'
-    module: 'Enhance Microsoft Copilot Studio agents'
+  title: Create agent flows
+  module: Enhance Microsoft Copilot Studio agents
+  description: In this lab, you will use the structured values collected in earlier
+    labs (such as property type, property name, and visit date) to retrieve data from
+    Dataverse and create a booking request in Dataverse.
+  duration: 164 minutes
+  level: 100
+  islab: true
 ---
 
 # Create agent flows

--- a/Instructions/Labs/08-generative-ai.md
+++ b/Instructions/Labs/08-generative-ai.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Use Generative AI in Microsoft Copilot Studio'
-    module: 'Enhance Microsoft Copilot Studio agents'
+  title: Use Generative AI in Microsoft Copilot Studio
+  module: Enhance Microsoft Copilot Studio agents
+  description: In this lab, you will prepare your agent for production use by configuring
+    grounding, fallback behavior, and safety controls while keeping generative AI
+    enabled.
+  duration: 120 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Microsoft Copilot
+  - Microsoft Copilot Studio
 ---
 
 # Use Generative AI in Microsoft Copilot Studio

--- a/Instructions/Labs/09-deploy-copilot-teams.md
+++ b/Instructions/Labs/09-deploy-copilot-teams.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Deploy agent to Microsoft Teams'
-    module: 'Create an agent with Microsoft Copilot Studio and Dataverse for Teams'
+  title: Deploy agent to Microsoft Teams
+  module: Create an agent with Microsoft Copilot Studio and Dataverse for Teams
+  description: 'In this exercise, you will:'
+  duration: 54 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Microsoft Teams
 ---
 
 # Deploy agent to Microsoft Teams


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 9

- `Instructions/Labs/01-create-copilot.md` (description,duration,level,islab)
- `Instructions/Labs/02-import-solution.md` (description,duration,level,islab)
- `Instructions/Labs/03-create-copilot.md` (description,duration,level,islab)
- `Instructions/Labs/04-manage-topics.md` (description,duration,level,islab)
- `Instructions/Labs/05-manage-nodes.md` (description,duration,level,islab)
- `Instructions/Labs/06-entities.md` (description,duration,level,islab)
- `Instructions/Labs/07-copilot-actions.md` (description,duration,level,islab)
- `Instructions/Labs/08-generative-ai.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/09-deploy-copilot-teams.md` (description,duration,level,islab,primarytopics)
