### PR TITLE
Backfill missing lab metadata (9 files)

### DIFF
--- a/Instructions/Labs/01-create-copilot.md
+++ b/Instructions/Labs/01-create-copilot.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create an agent with Copilot Studio'
-    module: 'Build an initial agent with Microsoft Copilot Studio'
+  title: Create an agent with Copilot Studio
+  module: Build an initial agent with Microsoft Copilot Studio
+  description: In this exercise, you’ll use Copilot Studio to create a simple agent that answers employee questions about expense policies in a fictional corporation.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Create an agent with Copilot Studio

--- a/Instructions/Labs/02-import-solution.md
+++ b/Instructions/Labs/02-import-solution.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Import Dataverse solution'
-    module: 'Build an initial agent with Microsoft Copilot Studio'
+  title: Import Dataverse solution
+  module: Build an initial agent with Microsoft Copilot Studio
+  description: In this exercise, you will import a Dataverse solution into your environment that contains the tables needed for the labs.
+  duration: 70 minutes
+  level: 100
+  islab: true
 ---
 
 # Import Dataverse solution

--- a/Instructions/Labs/03-create-copilot.md
+++ b/Instructions/Labs/03-create-copilot.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Build an initial agent'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Build an initial agent
+  module: Manage topics in Microsoft Copilot Studio
+  description: In this exercise, you will access the Microsoft Copilot Studio portal, select the appropriate environment, and create a new agent.
+  duration: 84 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft Copilot
+    - Microsoft Copilot Studio
 ---
 
 # Build an initial agent

--- a/Instructions/Labs/04-manage-topics.md
+++ b/Instructions/Labs/04-manage-topics.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Manage topics'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Manage topics
+  module: Manage topics in Microsoft Copilot Studio
+  description: In this exercise, you will use Copilot to create a topic from a description. This allows generative AI to draft the initial structure, which you can then refine.
+  duration: 102 minutes
+  level: 100
+  islab: true
 ---
 
 # Manage topics

--- a/Instructions/Labs/05-manage-nodes.md
+++ b/Instructions/Labs/05-manage-nodes.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Manage nodes'
-    module: 'Manage topics in Microsoft Copilot Studio'
+  title: Manage nodes
+  module: Manage topics in Microsoft Copilot Studio
+  description: In this lab, you created the Book Showing topic and used nodes to enforce a structured, step-by-step interaction while generative AI remained enabled. You also configured variable scope so information collected in Customer Details can be used across topics.
+  duration: 152 minutes
+  level: 100
+  islab: true
 ---
 
 # Manage nodes

--- a/Instructions/Labs/06-entities.md
+++ b/Instructions/Labs/06-entities.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Work with entities'
-    module: 'Work with entities and variables in Microsoft Copilot Studio'
+  title: Work with entities
+  module: Work with entities and variables in Microsoft Copilot Studio
+  description: In this lab, you used entities to extract structured values from natural language while keeping generative AI enabled. Entities allow your agent to accept flexible input while maintaining predictable behavior.
+  duration: 122 minutes
+  level: 100
+  islab: true
 ---
 
 # Work with entities

--- a/Instructions/Labs/07-copilot-actions.md
+++ b/Instructions/Labs/07-copilot-actions.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create agent flows'
-    module: 'Enhance Microsoft Copilot Studio agents'
+  title: Create agent flows
+  module: Enhance Microsoft Copilot Studio agents
+  description: In this exercise, you will create an agent flow that retrieves a property based on user‑provided criteria.
+  duration: 164 minutes
+  level: 100
+  islab: true
 ---
 
 # Create agent flows

--- a/Instructions/Labs/08-generative-ai.md
+++ b/Instructions/Labs/08-generative-ai.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Use Generative AI in Microsoft Copilot Studio'
-    module: 'Enhance Microsoft Copilot Studio agents'
+  title: Use Generative AI in Microsoft Copilot Studio
+  module: Enhance Microsoft Copilot Studio agents
+  description: 'In this lab, you actively configured generative AI behavior for production readiness by:'
+  duration: 120 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft Copilot
+    - Microsoft Copilot Studio
 ---
 
 # Use Generative AI in Microsoft Copilot Studio

--- a/Instructions/Labs/09-deploy-copilot-teams.md
+++ b/Instructions/Labs/09-deploy-copilot-teams.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Deploy agent to Microsoft Teams'
-    module: 'Create an agent with Microsoft Copilot Studio and Dataverse for Teams'
+  title: Deploy agent to Microsoft Teams
+  module: Create an agent with Microsoft Copilot Studio and Dataverse for Teams
+  description: In this lab, you deployed your agent to Microsoft Teams. Congratulations on completing your labs!
+  duration: 54 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft Teams
 ---
 
 # Deploy agent to Microsoft Teams


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 9

- `Instructions/Labs/01-create-copilot.md` (description,duration,level,islab)
- `Instructions/Labs/02-import-solution.md` (description,duration,level,islab)
- `Instructions/Labs/03-create-copilot.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/04-manage-topics.md` (description,duration,level,islab)
- `Instructions/Labs/05-manage-nodes.md` (description,duration,level,islab)
- `Instructions/Labs/06-entities.md` (description,duration,level,islab)
- `Instructions/Labs/07-copilot-actions.md` (description,duration,level,islab)
- `Instructions/Labs/08-generative-ai.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/09-deploy-copilot-teams.md` (description,duration,level,islab,primarytopics)
