### PR TITLE
fix(setup): update environment creation steps and copilot studio URL

### DIFF
--- a/Instructions/ILT_Setup/setup.md
+++ b/Instructions/ILT_Setup/setup.md
@@ -11,17 +11,17 @@ Before you start the lab exercise, let's create a development environment for yo
 2. Select **+New** to create a new environment with the following settings:
     - **Name**: *Your name*
     - **Make this a Managed Environment**: *No*
-    - **Group**: *None*
+    - **Environment group**: *None*
     - **Region**: ***default** region*
     - **Get new features early**: No
     - **Type**: Developer
     - **Create on behalf**: *No*
-    - **Add a Dataverse data store**: Yes
-    - **Pay-as-you-go with Azure**: No
-    - **Add Dataverse options**:
-        - **Language**: English
+    - **Add Dataverse**:
+        - **Language**: English (United States)
         - **Currency**: USD ($)
         - **Deploy sample apps and data**: No
 1. **Save** and wait until the state of your environment is **Ready** (you can use the **Refresh** button to update the display)
-1. Navigate to `https://copilotstudio.microsoft.com/` (sign in with your credentials if prompted).
+
+1. Select the newly created environment and, in the **Details** section, copy the **Environment ID** value.
+1. In the browser address bar, enter `https://copilotstudio.microsoft.com/environments/<Environment ID>`, replacing `<Environment ID>` with the value you copied. If prompted, sign in with your credentials.
 1. Skip any welcome messages.

--- a/Instructions/ILT_Setup/setup.md
+++ b/Instructions/ILT_Setup/setup.md
@@ -1,27 +1,21 @@
-# Add Dataverse to the default environment
-1. Open a web browser, navigate to `https://admin.powerplatform.microsoft.com/manage/environments`, and sign in using your credentials for this exercise. If prompted, choose the option to stay signed in.
-1. Close any pop-up messages that are displayed.
-1. Select the ellipses (**...**) for the **Contoso (default)** environment and select **Add Dataverse**.
-1. Leave all of the default settings and select **Add**.
-
 # Create an environment
 Before you start the lab exercise, let's create a development environment for you to work in.
 
-1. **Refresh** the **Environments** list.
-2. Select **+New** to create a new environment with the following settings:
-    - **Name**: *Your name*
-    - **Make this a Managed Environment**: *No*
-    - **Environment group**: *None*
-    - **Region**: ***default** region*
-    - **Get new features early**: No
+1. Open a web browser, navigate to `https://admin.powerplatform.microsoft.com/manage/environments`, and sign in using your credentials for this exercise. If prompted, choose the option to stay signed in.
+2. Close any pop-up messages that are displayed.
+3. Select **+New** to create a new environment with the following settings:
     - **Type**: Developer
-    - **Create on behalf**: *No*
-    - **Add Dataverse**:
-        - **Language**: English (United States)
-        - **Currency**: USD ($)
-        - **Deploy sample apps and data**: No
-1. **Save** and wait until the state of your environment is **Ready** (you can use the **Refresh** button to update the display)
-
-1. Select the newly created environment and, in the **Details** section, copy the **Environment ID** value.
-1. In the browser address bar, enter `https://copilotstudio.microsoft.com/environments/<Environment ID>`, replacing `<Environment ID>` with the value you copied. If prompted, sign in with your credentials.
-1. Skip any welcome messages.
+    - **Region**: ***default** region*
+    - **Name**: *Your name*
+4. Select **Next**
+5. Populate the following settings:
+    - **Language**: English (United States)
+    - **Currency**: USD ($)
+    - **Deploy sample apps and data**: No
+6. Select **Save** and wait until the state of your environment is **Ready** (you can use the **Refresh** button to update the display)
+7. Select the newly created environment
+8. In the **Details** section, copy the **Environment ID** value.
+9. In a new browser tab, enter `https://copilotstudio.microsoft.com/environments/<Environment ID>`, replacing `<Environment ID>` with the value you copied.
+    > **Note:** Save this URL so you can use it later to navigate directly to your environment. There is currently an issue opening Copilot Studio in the default environment. 
+11. If prompted, sign in with your credentials and skip any welcome messages.
+12. **Skip to Task 2 in the next lab to build your first agent.** 


### PR DESCRIPTION
## Summary

Resolves #58 - Missing instruction in the Add Dataverse to the default environment step 4, where learners were unable to load Copilot Studio because the product redirects to the default environment instead of the newly created one. This fix adds the missing steps to guide learners to navigate to Copilot Studio using the correct environment-specific URL.

## Changes

- Renamed the "Add Dataverse data store" setting label to "Add Dataverse" to reflect the current UI wording in Power Platform admin center.
- - Added a new step instructing learners to select the newly created environment and copy the Environment ID from the Details section.
- - Added a new step instructing learners to manually navigate to `https://copilotstudio.microsoft.com/environments/<Environment ID>` using the copied Environment ID, bypassing the default environment redirect.
- - Removed the generic Copilot Studio URL step that caused confusion when learners were redirected to a different environment.
## Files changed

- `Instructions/ILT_Setup/setup.md`