### PR TITLE
Fix(lab07): Rename Flow early to prevent FlowActionBadGateway and update post-publish UI navigation (closes #65)

### DIFF
--- a/Instructions/Labs/07-copilot-actions.md
+++ b/Instructions/Labs/07-copilot-actions.md
@@ -63,6 +63,16 @@ In this exercise, you will create an agent flow that retrieves a property based 
 
 1. Select **Save draft** near the upper-right of the page.
 
+1. Select the **Overview** tab.
+
+1. Select **Edit** in the **Details** section.
+
+1. Rename the agent flow `Get Property`
+
+1. Select **Save**.
+
+1. Select the **Designer** tab.
+
 ### Task 1.2 - Retrieve data from Dataverse
 
 1. Select the **+** icon between the two steps in the flow to add a new action.
@@ -137,13 +147,16 @@ In this exercise, you will create an agent flow that retrieves a property based 
 
 1. Select **Publish**.
 
-1. In the **Your agent flow published successfully!** pop-up, select **Go back to agent**.
+1. Navigate back to the **Real Estate Booking Service** agent in Microsoft Copilot Studio.
 
-1. Select the agent flow tool that you just created.
+1. Select the **Tools** tab.
 
-1. In the **Details** section, update the Flow **Name** to `Get Property`
+1. Select the **Get Property** agent flow tool that you just created.
 
-1. Update the **Description** to `Get properties with the right number of bedrooms`.
+   > [!NOTE]
+   > If you don't see the agent flow in the list of tools, select **+ Add a tool**, select the **Flow** tab, and select the **Get Property** agent flow. Select **Add and configure**.
+
+1. In the **Details** section, update the **Description** to `Get properties with the right number of bedrooms`.
 
 1. Select **Save**
 
@@ -275,7 +288,9 @@ Microsoft Copilot Studio can create data in Microsoft Dataverse using agent flow
 
 1. In **What do you want to do?**, enter: `After this action runs, send a message that the Real Estate Booking has been scheduled and thank the user`.
 
-1. Select **Update**. 
+1. Select **Update**.
+
+1. Select **Save**.
 
 A Message node has been created. Revise the message as desired to let the user know that a booking has been scheduled.
 


### PR DESCRIPTION
## Summary

This PR addresses fixes #65 in Lab 07, where filtering by Bedrooms triggers a `FlowActionBadGateway` error because the  Flow is reported as "Untitled". The root cause is that the Flow is created and published before being renamed, so Copilot Studio references it without a proper title. The lab instructions have been updated to rename the Flow early in the process and to reflect the current post-publish UI navigation in Copilot Studio.

## Changes

-  Updated Lab 07 instructions to rename the Flow immediately after creation, before publishing, so it is no longer reported as "Untitled".
- Flow not appearing on agent's Tools tab:
  - Added a [!NOTE] block (line 156) with the fallback path: + Add a tool → Flow tab → select Get Property → Add and configure.

- Adjusted the post-publish navigation steps to match the current Copilot Studio UI, ensuring learners can locate the Flow and continue the lab without hitting the FlowActionBadGateway error.
- Minor wording and formatting improvements in the affected section for clarity and consistency with the rest of the lab.

## Files changed

1. Instructions/Labs/07-copilot-actions.md

## Reply to issue #65 — [PL-7008] Lab 07: FlowActionBadGateway Error when filtering by Bedrooms (Flow reports as "Untitled")

- Flow named "Untitled" in error logs — FIXED
The flow is now renamed to "Get Property" immediately after creation (Task 1.1, steps 11–15 via the Overview tab), before any Dataverse actions are configured. If the List rows action times out, error logs will reference "Get Property" instead of "Untitled."

- Remaining concern — not fixable in lab instructions
The FlowActionBadGateway / NoResponse error itself (Dataverse List rows timing out) is a runtime environment issue — the Dataverse connection hangs on the learner's tenant. This is outside the scope of lab instructions. 

**Possible causes:**

- Dataverse connection not fully provisioned yet (common in fresh lab environments)
- DLP policy blocking the connector
- Transient service issue
- The lab instructions can't prevent this, but the two fixes above ensure learners can identify the failing flow and get it attached to the agent if it doesn't auto-attach.


## Tests

- End-to-end tested in a PL-7008 lab environment. The agent successfully retrieves a property by bedroom count and creates a booking request (screenshot attached).
<img width="1139" height="1726" alt="image" src="https://github.com/user-attachments/assets/1e3a4708-17b3-45dc-aa8a-c310c7abd7a3" />
