### PR TITLE
Update ILT setup instructions

### DIFF
--- a/Instructions/Labs/00-ILT-setup.md
+++ b/Instructions/Labs/00-ILT-setup.md
@@ -101,10 +101,6 @@ Before you start the lab exercises, you must create a development environment fo
 
 1. For **Prefix**, enter `fab`
 
-   ![New publisher.](../media/new-publisher.png)
-
-1. Select **Save**.
-
 1. Verify that **Fabrikam (fabrikam)** is selected in the **Publisher** drop-down.
 
 1. Select the **Set as your preferred solution** checkbox.


### PR DESCRIPTION
Removed image and save step from setup instructions. These steps are unnecessary now due to UI uopdate where save is not an option, only "create".

<img width="538" height="1151" alt="image" src="https://github.com/user-attachments/assets/8e02c933-e815-4fbb-a67d-8ed77be343b0" />