### PR TITLE
fix(lab04): fix topic output binding error and instruction formatting

### DIFF
--- a/Instructions/Labs/04-workflow-tools.md
+++ b/Instructions/Labs/04-workflow-tools.md
@@ -144,7 +144,7 @@ In this exercise, you create a workflow that sends a message to Microsoft Teams.
 1. Select **Sign in**.
 
    > [!NOTE]
-   > If you receive the error "Failed to create OAuth connection: ClientWarning: The browser has blocked the connection authentication popup window", select the **pop-up blocked** icon in the browser address bar and then select **Always allow pop-ups and redirects from `https://copilotstudio.microsoft.com**`.
+   > If you receive the error "Failed to create OAuth connection: ClientWarning: The browser has blocked the connection authentication popup window", select the **pop-up blocked** icon in the browser address bar and then select **Always allow pop-ups and redirects from `https://copilotstudio.microsoft.com`**.
 
 1. Select your account.
 
@@ -222,7 +222,7 @@ In this exercise, you create a workflow that sends a message to Microsoft Teams.
 
 1. In the **Instructions** section, select **Edit**.
 
-1. Under the *## Step-by-step instructions* in the agent instructions, add the following to the final step: `Use the ` and type `/` and select the **Send Summary to Teams** tool and then enter ` when the task analysis is complete.`
+1. Under the *# Step-by-Step Instructions* in the agent instructions, add the following to the final step: `Use the ` and type `/` and select the **Send Summary to Teams** tool and then enter ` when the task analysis is complete.`
 
    ![Screenshot of referencing the workflow tool in the agent instructions.](../media/workflow-add-tool-to-instructions.png)
 
@@ -397,7 +397,9 @@ In this exercise, you will use Copilot to create a topic from a description, cre
 
 1. For *Enter a name*, enter `Task list`.
 
-1. For *Enter a value to respond with*, use **Dynamic Content** and select the **body/value** from the **List rows present in a table** action.
+1. For *Enter a value to respond with*, select the field, and then select the **Expression** (**fx**) option. Enter the following expression to convert the returned rows into text that matches the **Text** output type, and then select **Add**:
+
+   `string(outputs('List_rows_present_in_a_table')?['body/value'])`
 
 1. Select **Save draft** near the upper-right of the page.
 


### PR DESCRIPTION
## Summary

This PR corrects three issues in Lab 4 (Create workflow tools). The most significant fix resolves the incorrect output binding error reported in issue #70, where the workflow returned an array to a variable declared as text. The remaining two changes fix Markdown formatting and an outdated instruction reference in Exercise 2.

Fix #70

## Response to issue #70

Thanks for the detailed write-up and root cause analysis. You're exactly right: `List rows present in a table` returns an array of objects, while the Response action declares the output parameter as **Text (string)**. Binding the raw `body/value` array to a string output is what triggers the "Output binding not found / data type not eligible to receive or return values" error in Task 3.5, Step 3.

We've taken the first suggested solution: instead of returning `body/value` directly, the lab now wraps it in `string(...)` so the returned value matches the declared **Text** output type. Exercise 3, Task 3.2 now instructs learners to use the **Expression** (**fx**) option and enter:

`string(outputs('List_rows_present_in_a_table')?['body/value'])`

This removes the confusing binding error while keeping the exercise's intent intact.

## Changes

### Exercise 3 — Task 3.2 (fixes #70)
- Replaced the response value step that used **Dynamic Content** → **body/value** with an **Expression** (**fx**) that wraps the value in `string(...)`.
- The `List rows present in a table` action returns an array of objects, but the Response action declares the output parameter as **Text (string)**. Binding the raw `body/value` array to a string output caused Copilot Studio to raise the "Output binding not found / data type not eligible" error in Task 3.5, Step 3.
- Learners now enter `string(outputs('List_rows_present_in_a_table')?['body/value'])`, which converts the returned rows to text that matches the declared output type and removes the binding error.

### Exercise 2 — Task 2.1
- Fixed a misplaced closing backtick in the pop-up allow instruction so the URL renders correctly as `https://copilotstudio.microsoft.com`.

### Exercise 2 — Task 2.5
- Corrected the agent instructions heading reference from `## Step-by-step instructions` to `# Step-by-Step Instructions` to match the actual heading in the instructions.

## Files changed

- `Instructions/Labs/04-workflow-tools.md` — Task 3.2: switched response output to an `fx` expression that casts the table rows to a string (resolves #70); Task 2.1: fixed backtick placement around the Copilot Studio URL; Task 2.5: corrected the step-by-step instructions heading reference.
