### PR TITLE
fix(lab05): align new experience steps with current Copilot Studio UI

### DIFF
--- a/Instructions/Labs/05-create-agent-new-experience.md
+++ b/Instructions/Labs/05-create-agent-new-experience.md
@@ -75,16 +75,16 @@ The new experience is best suited for agents that need to handle open-ended, con
 
 1. If you see a banner or notification prompting you to **Try the new experience**, select it.
 
-   Alternatively, select your profile icon in the upper-right corner and look for an option to switch to the **New experience** or **Preview**.
+   Alternatively, if you do not see the **New experience** toggle, navigate directly to `https://copilotstudio.preview.microsoft.com/` to open the new experience.
 
    > [!NOTE]
-   > The new experience may be the default in your environment. If you do not see a switch option, you are already using the new experience and can proceed to Exercise 2.
+   > The new experience may be the default in your environment. If the interface already matches the steps in this lab, you are using the new experience and can proceed to Exercise 2.
 
 ### Task 1.2 – Review the new interface
 
 Take a moment to review how the new experience is organized before creating your agent.
 
-1. In the left-hand navigation, note the main sections: **Agents**, **Tools**, and **Knowledge**.
+1. In the left-hand navigation, note the main sections: **Home**, **Agent Ops**, **Chat**, **Agents**, and **Workflows**.
 
 1. The **Agents** page shows any existing agents. Agents created in the new experience do not have a topic canvas — their behavior is defined entirely by instructions, knowledge, and actions on the agent's **Overview** page.
 
@@ -96,32 +96,40 @@ In this exercise, you will create an IT support agent for a fictional company ca
 
 ### Task 2.1 – Create the agent
 
-1. Select **Agents** in the left-hand navigation.
+1. Select **Home** in the left-hand navigation.
 
-1. Select **+ New agent**.
-
-1. In the agent creation dialog, enter the following description:
+1. On the **Home** page, enter the following description in the build prompt text box:
 
    ```prompt
    You are an IT support agent for Contoso. You help employees troubleshoot common IT issues such as password resets, software installation problems, and network connectivity. When you cannot resolve an issue, you help the employee submit a support ticket.
    ```
 
-1. Select **Create** or **Next** to provision the agent.
-
    > [!NOTE]
    > The new experience uses your description to automatically generate a set of initial instructions. Review them before continuing.
 
-1. In the **Solution** settings, verify that the **Lab Exercises** solution is selected and the schema name prefix is **fab**. Update these if needed.
+1. If prompted with clarifying questions, answer them to help the agent generate more accurate instructions. For example:
+
+   - If asked how employees submit IT support tickets, choose the option to send a support request email to the IT helpdesk (rather than ServiceNow, Jira, Dynamics 365, or Zendesk).
+   - If asked whether the agent should reference a knowledge base, SharePoint site, or website, choose the option indicating no external knowledge source is needed.
+
+   Select **Continue** to advance through the questions, or **Skip** any question that does not apply. Select **Submit** when finished.
+
+   > [!NOTE]
+   > Depending on your description and environment, the clarifying questions may vary or may not appear at all. Answer them in line with the lab scenario rather than expecting these exact questions or answer options.
+
+1. If prompted for the email address the agent should use when sending support requests, enter your admin email address, then select **Submit**.
+
+1. Select **Keep it** to accept the auto-generated instructions and create the agent.
+
+1. In the **Artifacts** panel on the right, select your agent to open its **Build** tab.
 
 ### Task 2.2 – Review and refine the auto-generated instructions
 
-1. On the agent's **Overview** page, locate the **Instructions** section.
+1. On the agent's **Build** tab, locate the **Instructions** section.
 
 1. Review the instructions that were generated from your description. They should describe the agent's purpose, tone, and general behavior.
 
-1. Select **Edit** in the **Instructions** section.
-
-1. Update the instructions to include the following guidelines, either by typing or by using **Edit with Copilot**:
+1. In the **Instructions** section, update the instructions to include the following guidelines:
 
    ```prompt
    ## Guidelines
@@ -129,70 +137,28 @@ In this exercise, you will create an IT support agent for a fictional company ca
    - For password reset requests, direct the employee to the self-service portal at https://aka.ms/sspr before offering to raise a ticket.
    - For issues you cannot resolve, collect the employee's name, email address, and a brief description of the issue before submitting a ticket.
    - Do not speculate about hardware failures. Always recommend contacting the IT desk directly for physical hardware issues.
+   - When an employee's issue cannot be resolved, use the Send an email action to notify the IT helpdesk at helpdesk@contoso.com with the employee's name, email, and issue description.
    ```
-
-1. Select **Save**.
-
+   
    > [!NOTE]
    > Instructions in the new experience are the primary way to control agent behavior. Well-written instructions reduce the need for additional configuration and make the agent more predictable.
 
-## Exercise 3 - Add an action
-
-In Lab 03, adding an action required you to build a Power Automate workflow from scratch, configure its inputs and outputs, publish it, and then add it to the agent as a tool. In the new experience, you can add a prebuilt connector action directly in Copilot Studio without leaving the page or authoring a flow. This exercise demonstrates that difference.
-
-### Task 3.1 – Add a prebuilt action
-
-1. On the agent's **Overview** page, select the **Actions** tab or locate the **Actions** section.
-
-1. Select **+ Add action**.
-
-1. Browse the available prebuilt actions and select **Send an email** from the **Microsoft 365** or **Outlook** connector.
-
-   > [!NOTE]
-   > If **Send an email** is not available in your environment, select any available prebuilt action and adapt the remaining steps accordingly.
-
-1. Sign in when prompted to authorize the connector.
-
-1. Select **Add and configure**.
-
-1. In the **Details** section, update the **Description** to:
-
-   `Send a support ticket notification email to the IT helpdesk when an issue cannot be resolved by the agent.`
-
-1. In the **When this action may be used** setting, select **Only when referenced in instructions or by the agent**.
-
-1. Select **Save**.
-
-### Task 3.2 – Reference the action in instructions
-
-The agent will only use the action if its instructions tell it when to do so.
-
-1. Return to the **Instructions** section on the **Overview** tab and select **Edit**.
-
-1. Add the following line under your existing guidelines:
-
-   ```prompt
-   - When an employee's issue cannot be resolved, use the Send an email action to notify the IT helpdesk at helpdesk@contoso.com with the employee's name, email, and issue description.
-   ```
-
-1. Select **Save**.
-
-## Exercise 4 - Test and refine
+## Exercise 3 - Test and refine
 
 In this exercise, you will test the agent and observe how it reasons before responding.
 
-### Task 4.1 – Open the test pane
+### Task 3.1 – Open the Preview tab
 
-1. Select the **Test** icon in the upper-right of the page to open the **Test** pane.
+1. Select the **Preview** tab at the top of the page to test the agent.
 
-1. If available, enable **Show reasoning** or **Show thinking steps** in the test pane options. This shows how the agent decides what to do before generating a response.
+1. When you test the agent, a reasoning summary appears automatically above each response, describing how the agent decided what to do. Select **Show more** on that summary to expand the full reasoning trace.
 
    > [!NOTE]
-   > The reasoning trace is a key feature of the new experience. It shows which knowledge sources or actions the agent considered and why.
+   > The reasoning trace is a key feature of the new experience. It shows which knowledge sources or actions the agent considered and why — for example, a **Loaded Skill** entry indicates which action or skill the agent invoked.
 
-### Task 4.2 – Test the instructions
+### Task 3.2 – Test the instructions
 
-1. At the top of the **Test** pane, select the **Start new test session** icon **+**.
+1. At the top of the **Preview** tab, select **New chat**.
 
 1. Enter the following prompt:
 
@@ -202,9 +168,9 @@ In this exercise, you will test the agent and observe how it reasons before resp
 
    Based on the instructions you wrote, the agent should direct you to the self-service portal before offering to raise a ticket.
 
-### Task 4.3 – Test the action
+### Task 3.3 – Test the agent's reasoning behavior
 
-1. At the top of the **Test** pane, select the **Start new test session** icon **+**.
+1. At the top of the **Preview** tab, select **New chat**.
 
 1. Enter the following prompt:
 
@@ -212,17 +178,15 @@ In this exercise, you will test the agent and observe how it reasons before resp
    My laptop will not turn on at all.
    ```
 
-   Based on the instructions you wrote, the agent should decline to speculate about hardware failures and offer to contact the IT desk or submit a ticket.
+   Based on the instructions you wrote, the agent should decline to troubleshoot the hardware failure remotely, recommend contacting the IT desk directly, and offer to submit a support ticket on your behalf.
 
-1. Follow the agent's prompts to provide your name, email, and issue description.
+1. Follow the agent's prompts to provide your name, email, and a brief description of the issue.
 
-   If the **Send an email** action is triggered, you may be prompted to authorize the connection. Select **Allow** if prompted.
-
-### Task 4.4 – Refine instructions based on test results
+### Task 3.4 – Refine instructions based on test results
 
 1. Review how the agent responded across the three test sessions.
 
-1. If any response was not aligned with the intended behavior, select **Edit** in the **Instructions** section and adjust the relevant guideline.
+1. If any response was not aligned with the intended behavior, select the **Build** tab, and in the **Instructions** section, adjust the relevant guideline.
 
    For example, if the agent did not mention the self-service portal for password resets, make the instruction more explicit:
 
@@ -230,11 +194,11 @@ In this exercise, you will test the agent and observe how it reasons before resp
    - For ALL password-related requests, always mention https://aka.ms/sspr as the first step before any other assistance.
    ```
 
-1. Select **Save** and re-test the affected scenario.
+1. Select **Publish**, then select **Save and Publish**, and re-test the affected scenario.
 
    > [!NOTE]
    > Iterating on instructions is the primary tuning mechanism in the new experience. Small changes in wording can significantly change agent behavior.
 
 ## Summary
 
-In this lab, you used the new Copilot Studio experience to create an instruction-driven IT support agent. You configured behavior entirely through natural language instructions and added a prebuilt connector action directly in Copilot Studio — without building a Power Automate workflow or leaving the page. Compared to Lab 03, where adding a tool required authoring a workflow, configuring inputs and outputs, and publishing it separately, the new experience significantly reduces the authoring effort for straightforward actions. You also used the reasoning trace in the test pane to observe how the agent decided what to do before generating a response. Having worked with both the classic and new experiences, you can now choose the right approach for each scenario: instruction-driven for open-ended conversations, and classic topics and workflows when you need a guaranteed, auditable sequence of steps.
+In this lab, you used the new Copilot Studio experience to create an instruction-driven IT support agent. You configured behavior entirely through natural language instructions and added a prebuilt connector action directly in Copilot Studio — without building a Power Automate workflow or leaving the page. Compared to Lab 03, where adding a tool required authoring a workflow, configuring inputs and outputs, and publishing it separately, the new experience significantly reduces the authoring effort for straightforward actions. You also used the reasoning trace in the Preview pane to observe how the agent decided what to do before generating a response. Having worked with both the classic and new experiences, you can now choose the right approach for each scenario: instruction-driven for open-ended conversations, and classic topics and workflows when you need a guaranteed, auditable sequence of steps.


### PR DESCRIPTION
## Summary

This PR updates Lab 05 (Create an agent in the new experience) so its steps match the current new Copilot Studio experience UI. The agent-creation flow, navigation, testing, and publishing steps were reworked, and the standalone "Add an action" exercise was folded into the agent instructions — reducing the lab from four exercises to three.

## Changes

- **Task 1.1** — Replaced the profile-menu switch instructions with direct navigation to the preview URL for when the **New experience** toggle isn't visible.
- **Task 1.2** — Updated the left-hand navigation sections to **Home**, **Agent Ops**, **Chat**, **Agents**, and **Workflows**.
- **Task 2.1** — Reworked agent creation to use the **Home** page build prompt box, handle clarifying questions and the support-email prompt, accept the auto-generated instructions with **Keep it**, and open the agent from the **Artifacts** panel to its **Build** tab.
- **Task 2.2** — Moved instruction editing to the **Build** tab and merged the **Send an email** helpdesk guideline directly into the instructions.
- **Removed the separate Exercise 3 (Add an action)** — the action is now referenced through instructions instead of a separately configured prebuilt connector.
- **Renumbered Exercise 4 to Exercise 3 (Test and refine)** — test pane → **Preview** tab, **Start new test session** → **New chat**, reasoning trace via **Show more**, and publishing via **Publish** → **Save and Publish**.
- **Summary** — Updated wording from "test pane" to "Preview pane".

## Files changed

- `Instructions/Labs/05-create-agent-new-experience.md` — Updated Lab 05 steps to match the current new Copilot Studio UI and consolidated four exercises into three (39 insertions, 75 deletions).
