### PR TITLE
fix(lab00/ex01/t03): enable Dataverse manually in dev environment setup

### DIFF
--- a/Instructions/Labs/00-ILT-setup.md
+++ b/Instructions/Labs/00-ILT-setup.md
@@ -38,12 +38,15 @@ Before you start the lab exercises, you must create a development environment fo
    - **Type**: Developer
    - **Region**: default region
    - **Name**: *Your name*
+
+   ![Create an environment in the Power Platform Admin center.](../media/create-environment.png)
+
+1. Expand **Change default settings** and configure the following:
    - **Environment group**: None
    - **Make this a Managed Environment**: No
    - **Get new features early**: No
    - **Create on behalf**: No
-
-   ![Create an environment in the Power Platform Admin center.](../media/create-environment.png)
+   - **Add a Dataverse data store?**: Yes
 
 1. Select **Next** and in the **Add Dataverse** section:
 
@@ -61,7 +64,7 @@ Before you start the lab exercises, you must create a development environment fo
 1. In a new browser tab, navigate to `https://copilotstudio.microsoft.com/` and sign in if prompted.
 
   > [!NOTE]  
-  > If you experience issues loading Copilot Studio or your environment:
+  > If you experience issues loading Copilot Studio on your environment:
   > - First, capture your environment ID (GUID) from the Power Platform admin center:
   >   1. Open the environment you created at `https://admin.powerplatform.microsoft.com/manage/environments`.
   >   2. Locate the environment ID in the URL (a long string such as `12345678-90ab-cdef-1234-567890abcdef`).
@@ -100,6 +103,8 @@ Before you start the lab exercises, you must create a development environment fo
 1. For **Name**, enter `fabrikam`
 
 1. For **Prefix**, enter `fab`
+
+1. Select **Save** to create the publisher.
 
 1. Verify that **Fabrikam (fabrikam)** is selected in the **Publisher** drop-down.
 


### PR DESCRIPTION
## Summary

Updates the ILT setup lab to reflect the current Power Platform admin center UI, where new Developer environments no longer enable Dataverse by default. Learners must now expand **Change default settings** and manually add a Dataverse data store. Also corrects a small wording issue in the Copilot Studio troubleshooting note.

Fix #73 

## Reply to the issue

Developer environments no longer default to having Dataverse enabled. Exercise 1, Task 1.3 has been updated so learners now:

1. Expand **Change default settings** after entering the environment name.
2. Set **Add a Dataverse data store?** to **Yes** to manually enable Dataverse.

The create-environment screenshot was also repositioned to match the new step order.

## Changes

- **Lab 00 / Exercise 1 / Task 1.3**: Added an explicit step to expand **Change default settings** and set **Add a Dataverse data store?** to **Yes**, since new Developer environments no longer enable Dataverse automatically.
- Repositioned the create-environment screenshot to align with the updated step order.
- Fixed wording in the Copilot Studio troubleshooting note ("loading Copilot Studio **or** your environment" → "**on** your environment").

## Files changed

- `Instructions/Labs/00-ILT-setup.md` — Reordered and expanded the Task 1.3 environment creation steps to manually enable Dataverse, moved the create-environment screenshot, and corrected the troubleshooting note wording.
