### PR TITLE
fix(lab04): resolve priority type mismatch and unreliable tool calls

### DIFF
--- a/Instructions/Labs/04-workflow-tools.md
+++ b/Instructions/Labs/04-workflow-tools.md
@@ -218,11 +218,34 @@ In this exercise, you create a workflow that sends a message to Microsoft Teams.
 
 ### Task 2.5 - Update agent instructions
 
+> [!IMPORTANT]
+> The instructions that Copilot generates when it creates an agent vary, and they're often long and general. Those instructions can cause the agent to answer from knowledge or ask the user for a list of tasks instead of calling your topics and tools. In this task, you replace the generated instructions with a specific set of instructions so that the agent behaves predictably in the remaining exercises.
+
 1. Select the **Overview** tab.
 
 1. In the **Instructions** section, select **Edit**.
 
-1. Under the *# Step-by-Step Instructions* in the agent instructions, add the following to the final step: `Use the ` and type `/` and select the **Send Summary to Teams** tool and then enter ` when the task analysis is complete.`
+1. Select all of the existing text in the **Instructions** box and delete it.
+
+1. Enter the following instructions. Where the text shows a placeholder such as `<Send Summary to Teams>`, don't type the placeholder. Instead, type `/`, and then select the **Send Summary to Teams** tool from the list so that the tool is inserted as a reference:
+
+   ```prompt
+   # Purpose
+   The purpose of this agent is to analyze, categorize, and prioritize tasks, and to send a summary of the analysis to a Microsoft Teams channel.
+
+   # General guidelines
+   - Maintain a professional and supportive tone.
+   - Always use the topics and tools listed below. Don't answer from your own knowledge.
+
+   # Skills
+   - Use the <Send Summary to Teams> tool to post a summary of the task analysis to Microsoft Teams.
+
+   # Step-by-step instructions
+   1. Analyze tasks
+      - Categorize and prioritize the tasks that the user provides.
+   2. Send the results
+      - Use the <Send Summary to Teams> tool when the task analysis is complete.
+   ```
 
    ![Screenshot of referencing the workflow tool in the agent instructions.](../media/workflow-add-tool-to-instructions.png)
 
@@ -258,7 +281,7 @@ In this exercise, you will use Copilot to create a topic from a description, cre
 
 ### Task 3.1 - Create an Excel file
 
-[!NOTE]
+> [!NOTE]
 > If you have issues creating this spreadsheet you can download a copy from this link [Download the file](../../Allfiles/Operations%20tasks.xlsx)
 
 1. In Copilot Studio, select the **App launcher** icon in the upper-left corner, then select **OneDrive**.
@@ -374,7 +397,7 @@ In this exercise, you will use Copilot to create a topic from a description, cre
 
 1. Select **Sign in** to create a connection.
 
-1. In the **Sign into your account** dialog, select the account you are using for this lab environment (such as **MOD Administrator**), select the **I have verified this request and trust the source** checkbox, and select **Allow access**.
+1. In the **Sign into your account** dialog, select the account you are using for this lab environment (such as **MOD Administrator**). If prompted, select the **I have verified this request and trust the source** checkbox, and select **Allow access**.
 
 1. For **Location** select **OneDrive for Business**.
 
@@ -465,6 +488,8 @@ In this exercise, you will use Copilot to create a topic from a description, cre
 
    ![Screenshot of the inputs of workflow as a tool.](../media/workflow-tool-inputs.png)
 
+1. Select the ellipsis (**...**) next to the **Global.Priority** value, select **Formula** (**fx**), enter `Text(Global.Priority)`, and then select **Insert**. The **Priority** question stores a choice value, and the workflow requires text, so this formula converts the value and prevents a type mismatch error.
+
 1. In the **Completion** section, for **After running**, select **Write the response with generative AI**.
 
 1. Select **Save**.
@@ -487,7 +512,9 @@ In this exercise, you will use Copilot to create a topic from a description, cre
 
 1. In the **Instructions** section, select **Edit**.
 
-1. Under the *## Skills* in the agent instructions, add the following to the final step: `Use the ` and type `/` and select the **Priority Tasks** topic and then enter ` to get the task list.`
+1. In the *# Skills* section, add a new line, enter `- Use the `, type `/`, select the **Priority Tasks** topic, and then enter ` topic to get the task list.`
+
+1. In the *# Step-by-step instructions* section, under **1. Analyze tasks**, add a new line, enter `- Use the `, type `/`, select the **Priority Tasks** topic, and then enter ` topic to get the task list.`
 
 1. Select **Save**.
 
@@ -504,6 +531,9 @@ In this exercise, you will use Copilot to create a topic from a description, cre
    `Analyze the task list`
 
 1. The **Priority Tasks** topic will be shown.
+
+   > [!NOTE]
+   > If the agent answers without opening the **Priority Tasks** topic, verify on the **Overview** tab that the agent instructions reference the **Priority Tasks** topic and the **Send Summary to Teams** tool as inserted references, and then start a new test session.
 
 1. Select **Medium**.
 


### PR DESCRIPTION
## Summary

Fixes the two problems reported in #76 for **Lab 04 - Use Workflows as Tools**: the `Priority` global variable is a choice value that the workflow rejects because it expects text, and the Copilot-generated agent instructions are too broad, so the agent answers from knowledge instead of calling the topic and the workflow tool. This PR adds the missing `Text()` conversion step, replaces the generated instructions with a deterministic set, and cleans up a few small formatting and accuracy issues in the same lab.

## Reply to issue #76

>  Thank you for the detailed report and for including the screenshots from your class. Both problems are reproducible, and this PR addresses each one.
>
> **1. Priority variable type conversion (Exercise 3, Task 3.5)**
>
> You're right that the step is missing. The **Priority** question stores a choice value, but the **Get Task List** workflow input expects a string, so binding `Global.Priority` directly produces the type mismatch error in your first screenshot. The lab now includes an explicit step in **Task 3.4 - Add the workflow as a tool**, immediately after the **Priority** global variable is selected as the custom value, that tells the learner to open the ellipsis (**...**) menu on the value, choose **Formula** (**fx**), and enter `Text(Global.Priority)` â€” exactly the workaround you used. It's placed in Task 3.4 rather than Task 3.5 because that's where the tool inputs are configured, so the learner never sees the error state.
>
> **2. The agent not calling the workflows during testing**
>
> Your diagnosis is correct. The instructions Copilot generates when it creates the agent vary between runs and are usually long and general, which is enough for the orchestrator to satisfy "Analyze the task list" from knowledge or by asking the learner to paste a list, instead of routing to the topic and tool. **Task 2.5 - Update agent instructions** now has the learner delete the generated instructions entirely and enter a short, explicit set of instructions with **Purpose**, **General guidelines**, **Skills**, and **Step-by-step instructions** sections, including a "Don't answer from your own knowledge" guideline. **Task 3.5** then extends those same instructions with the **Priority Tasks** topic reference in both the **Skills** and **Step-by-step instructions** sections, so the topic is reachable from the orchestrator. A troubleshooting note was also added to the testing step in case the agent still answers without opening the topic.
>
> The instruction set is intentionally close in shape to the one you shared with your class, adapted to the lab's naming and to the `/` reference syntax so that the topic and tool are inserted as real references rather than plain text.

## Changes

### Exercise 2 - Task 2.5 (Update agent instructions)

- Added an `[!IMPORTANT]` note explaining that Copilot-generated instructions vary and can prevent the agent from calling topics and tools.
- Replaced the "append one line to the generated instructions" step with instructions to delete the generated text and enter a complete, deterministic instruction set (**Purpose**, **General guidelines**, **Skills**, **Step-by-step instructions**).
- Clarified that `<Send Summary to Teams>` is a placeholder and that the learner must type `/` and select the tool so it's inserted as a reference.

### Exercise 3 - Task 3.1 (Create an Excel file)

- Fixed a malformed alert: `[!NOTE]` was missing its `>` blockquote marker, so it rendered as literal text instead of a note.

### Exercise 3 - Task 3.3 (Create the workflow)

- Made the **I have verified this request and trust the source** checkbox conditional (`If prompted, ...`), since it isn't always shown.

### Exercise 3 - Task 3.4 (Add the workflow as a tool)

- Added the missing step to convert the **Priority** choice value to text with the `Text(Global.Priority)` formula, with an explanation of why the conversion is required.

### Exercise 3 - Task 3.5 (Add workflow tool to the topic)

- Replaced the vague "Under the *## Skills*... add the following to the final step" instruction with two precise steps that add the **Priority Tasks** topic reference to both the **# Skills** and **# Step-by-step instructions** sections, matching the new instruction structure from Task 2.5.

### Exercise 3 - Task 3.6 (Test the topic)

- Added a `[!NOTE]` troubleshooting tip for when the agent responds without opening the **Priority Tasks** topic.

## Files changed

- `Instructions/Labs/04-workflow-tools.md`

Fixes #76 